### PR TITLE
kb: use tun mode in docker example

### DIFF
--- a/01-authkey/compose.yaml
+++ b/01-authkey/compose.yaml
@@ -8,6 +8,7 @@ services:
     environment:
       - TS_AUTHKEY=tskey-auth-kV7bYL6CNTRL-GXXhAHWhHXAVTcumJyyxXAc2cyjxQ3QkD
       - TS_STATE_DIR=/var/lib/tailscale
+      - TS_USERSPACE=false
     volumes:
       - ${PWD}/ts-authkey-test/state:/var/lib/tailscale
       - /dev/net/tun:/dev/net/tun

--- a/02-oauth/compose.yaml
+++ b/02-oauth/compose.yaml
@@ -9,6 +9,7 @@ services:
       - TS_AUTHKEY=tskey-client-kwLoXj6CNTRL-vCLN9Ab8QYYoLSEM98riXYLnfmtej6Lh?ephemeral=true
       - TS_EXTRA_ARGS=--advertise-tags=tag:container
       - TS_STATE_DIR=/var/lib/tailscale
+      - TS_USERSPACE=false
     volumes:
       - ${PWD}/ts-oauth-test/state:/var/lib/tailscale
       - /dev/net/tun:/dev/net/tun

--- a/04-ts-mealie/compose.yaml
+++ b/04-ts-mealie/compose.yaml
@@ -10,6 +10,7 @@ services:
       - "TS_EXTRA_ARGS=--advertise-tags=tag:container --reset"
       - TS_SERVE_CONFIG=/config/mealie.json
       - TS_STATE_DIR=/var/lib/tailscale
+      - TS_USERSPACE=false
     volumes:
       - ${PWD}/state:/var/lib/tailscale
       - ${PWD}/config:/config


### PR DESCRIPTION
If we're passing `/dev/net/tun` to the container, we should probably be actually using it.

Fixes tailscale/tailscale#11219