### PR TITLE
Remove sys_module from compose.yaml

### DIFF
--- a/01-authkey/compose.yaml
+++ b/01-authkey/compose.yaml
@@ -15,7 +15,6 @@ services:
       - /dev/net/tun:/dev/net/tun
     cap_add:
       - net_admin
-      - sys_module
     restart: unless-stopped
   nginx-authkey-test:
     image: nginx

--- a/02-oauth/compose.yaml
+++ b/02-oauth/compose.yaml
@@ -16,7 +16,6 @@ services:
       - /dev/net/tun:/dev/net/tun
     cap_add:
       - net_admin
-      - sys_module
     restart: unless-stopped
   nginx-oauth-test:
     image: nginx

--- a/03-nginx-example/compose.yaml
+++ b/03-nginx-example/compose.yaml
@@ -15,7 +15,6 @@ services:
       - /dev/net/tun:/dev/net/tun
     cap_add:
       - net_admin
-      - sys_module
     restart: unless-stopped
   nginx-pid-test1:
     image: nginx

--- a/04-ts-mealie/compose.yaml
+++ b/04-ts-mealie/compose.yaml
@@ -18,7 +18,6 @@ services:
       - /dev/net/tun:/dev/net/tun
     cap_add:
       - net_admin
-      - sys_module
     restart: unless-stopped
   mealie:
     image: ghcr.io/mealie-recipes/mealie:v1.0.0

--- a/05-ts-immich-gpu/linux-host/compose.yaml
+++ b/05-ts-immich-gpu/linux-host/compose.yaml
@@ -5,7 +5,6 @@ services:
     container_name: immich-ts
     cap_add:
       - net_admin
-      - sys_module
     volumes:
       - /home/alex/appdata/immich/tailscale/state:/var/lib/tailscale
       - /home/alex/appdata/immich/serveconfig:/config

--- a/06-quickstart-vid/01-nginx-basic/docker-compose.yaml
+++ b/06-quickstart-vid/01-nginx-basic/docker-compose.yaml
@@ -13,7 +13,6 @@ services:
       - /dev/net/tun:/dev/net/tun
     cap_add:
       - net_admin
-      - sys_module
     restart: unless-stopped
   nginx-authkey-test:
     image: nginx

--- a/06-quickstart-vid/02-stirlingpdf/docker-compose.yaml
+++ b/06-quickstart-vid/02-stirlingpdf/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
       - /dev/net/tun:/dev/net/tun
     cap_add:
       - net_admin
-      - sys_module
     restart: unless-stopped
   stirlingpdf:
     image: frooodle/s-pdf:latest


### PR DESCRIPTION
Same as https://github.com/tailscale/tailscale-www/pull/7269, that capability isn't actually needed.