### PR TITLE
initial commit of Actual Budget server example

### DIFF
--- a/07-ts-actual-server/README.md
+++ b/07-ts-actual-server/README.md
@@ -1,0 +1,21 @@
+# tailscale-dev/docker-guide-code-examples/07-ts-actual-server
+
+This has been tested on Synology DSM 7.2.2 and running Synology Container Manager.
+
+Steps to get this working:
+
+1. Create a new `Project` in Container Manager. Name it `actual-server` or something identifiable.
+2. Under the `Yaml Configurations` tab, paste this `compose.yaml` file as is. 
+3. Modify the yaml and insert your own Tailscale AuthKey.
+4. Using the Synology File Station (or similar) make sure to create the correct folders so that the Docker files can save their data in the mounted volumes.
+5. Copy up the `serve-config.json` into the `/config` folder volume mount as well.
+6. If you haven't done so already, save and build the project. After a few minutes it should build and start the Actual Server container.
+7. Open up your Actual Server client and add the `https://<FQDN.TS.NET>` of your container and it should see it and start syncing!
+
+Go and budget away! Please file a bug issue if you run into any problems with this example!
+
+Actual Server Docker info:
+
+- https://actualbudget.com/docs/install/docker
+- Docker Compose file - https://github.com/actualbudget/actual/blob/master/packages/sync-server/docker-compose.yml
+

--- a/07-ts-actual-server/compose.yaml
+++ b/07-ts-actual-server/compose.yaml
@@ -1,0 +1,39 @@
+services:
+  ts-actual-server:
+    image: tailscale/tailscale:latest
+    ports:
+      # This line makes Actual available at port 5006 of the device you run the server on,
+      # i.e. http://localhost:5006. You can change the first number to change the port, if you want.
+      - '5006:5006'
+    container_name: ts-as
+    hostname: actual-server
+    environment:
+      - TS_AUTHKEY=tskey-auth-<YOUR AUTH KEY HERE>
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_USERSPACE=false
+      - TS_SERVE_CONFIG=/config/serve-config.json
+    volumes:
+      - ./ts-actual-server/state:/var/lib/tailscale
+      - ./ts-actual-server/config:/config
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - net_admin
+    restart: unless-stopped
+  actual_server:
+    image: docker.io/actualbudget/actual-server:latest
+    network_mode: service:ts-actual-server
+    depends_on:
+      - ts-actual-server
+    volumes:
+      # Change './actual-data' below to the path to the folder you want Actual to store its data in on your server.
+      # '/data' is the path Actual will look for its files in by default, so leave that as-is.
+      - ./actual-data:/data
+    healthcheck:
+      # Enable health check for the instance
+      test: ['CMD-SHELL', 'node src/scripts/health-check.js']
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    restart: unless-stopped

--- a/07-ts-actual-server/config/serve-config.json
+++ b/07-ts-actual-server/config/serve-config.json
@@ -1,0 +1,19 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://127.0.0.1:5006"
+        }
+      }
+    }
+  },
+  "AllowFunnel": {
+    "${TS_CERT_DOMAIN}:443": false
+  }
+}


### PR DESCRIPTION
An example of using Tailscale with the Actual Budget docker container.